### PR TITLE
Streamline dark editor background with freya adjustments

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,51 +1,51 @@
-import * as monaco from 'monaco-editor'
-import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
-import { configureMonacoYaml } from 'monaco-yaml'
-import YamlWorker from './yaml.worker.js?worker'
+import * as monaco from 'monaco-editor';
+import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+import { configureMonacoYaml } from 'monaco-yaml';
+import YamlWorker from './yaml.worker.js?worker';
 
 window.MonacoEnvironment = {
   getWorker(moduleId, label) {
     switch (label) {
       case 'editorWorkerService':
-        return new EditorWorker()
+        return new EditorWorker();
       case 'yaml':
-        return new YamlWorker()
+        return new YamlWorker();
       default:
-        throw new Error(`Unknown label ${label}`)
+        throw new Error(`Unknown label ${label}`);
     }
   },
-  setTheme: function(theme) {
-    monaco.editor.defineTheme('monaco-yaml-theme', themeData(theme))
+  setTheme: function (theme) {
+    monaco.editor.defineTheme('monaco-yaml-theme', themeData(theme));
   }
-}
+};
 
 configureMonacoYaml(monaco, {
   enableSchemaRequest: true
-})
+});
 
 window.yamlEditor = {
-  create: function(element, uri, content, theme) {
-    monaco.editor.defineTheme('monaco-yaml-theme', themeData(theme))
-    monaco.editor.setTheme('monaco-yaml-theme')
-    monaco.languages.html.registerHTMLLanguageService('xml', {}, { documentFormattingEdits: true })
+  create: function (element, uri, content, theme) {
+    monaco.editor.defineTheme('monaco-yaml-theme', themeData(theme));
+    monaco.editor.setTheme('monaco-yaml-theme');
+    monaco.languages.html.registerHTMLLanguageService('xml', {}, { documentFormattingEdits: true });
     return monaco.editor.create(element, {
       automaticLayout: true,
       model: monaco.editor.createModel(content, undefined, monaco.Uri.parse(uri)),
-      tabSize: 2, 
+      tabSize: 2,
       renderWhitespace: 'all'
     });
   },
-  uri: function(uriRaw) {
+  uri: function (uriRaw) {
     return monaco.Uri.parse(uriRaw);
   }
-}
+};
 
 function themeData(theme) {
   if (theme == 'dark') {
     return {
       base: 'vs-dark',
       colors: {
-        'editor.background': '#293241'
+        'editor.background': '#2c2c2c'
       },
       inherit: true,
       rules: []


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/126dd29a-84fe-493b-af0d-b036ae661947)

after:
![image](https://github.com/user-attachments/assets/64891d92-9004-44f4-9e77-d08c3f0c0385)
