### PR TITLE
Generate bom, upload it to dtrack and publish bom as maven artifact for re-integration

### DIFF
--- a/.ivy/raise-version.sh
+++ b/.ivy/raise-version.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-mvn versions:set -DnewVersion=${1} -DprocessAllModules
-mvn versions:commit -DprocessAllModules
+mvn --batch-mode -f build/sbom/pom.xml versions:set versions:commit -DnewVersion=${1}
+mvn --batch-mode versions:set versions:commit -DnewVersion=${1} -DprocessAllModules

--- a/build/Dockerfile.maven
+++ b/build/Dockerfile.maven
@@ -1,0 +1,1 @@
+FROM maven:3.9.9-eclipse-temurin-21

--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
         script {
           catchError(buildResult: 'UNSTABLE', stageResult: 'UNSTABLE') {
             docker.build('node', '-f build/Dockerfile .').inside {
-              sh 'npm install && npm run build'
+              sh 'npm install && npm run build && npm run sbom'
             }
           }
           archiveArtifacts artifacts: 'dist/**', allowEmptyArchive: false
@@ -35,13 +35,26 @@ pipeline {
         }
       }
     }
+    stage('bom') {
+      steps {
+        script {
+          if (isReleasingBranch()) {
+            docker.build('maven-build', '-f build/Dockerfile.maven .').inside {        
+              def version = sh (script: "mvn help:evaluate -Dexpression=project.version -q -DforceStdout", returnStdout: true)
+              maven cmd: '-f build/sbom/pom.xml clean deploy'
+              uploadBOM(projectName: 'monaco-yaml-ivy', projectVersion: version, bomFile: 'bom.json')
+            }
+          }
+        }
+      }
+    }
     stage('Deploy') {
       when {
-        expression { isReleaseOrMasterBranch() && currentBuild.changeSets.size() > 0 }
+        expression { isReleasingBranch() && currentBuild.changeSets.size() > 0 }
       }
       steps {
         script {
-          docker.image('maven:3.8.6-eclipse-temurin-17').inside {
+          docker.build('maven-build', '-f build/Dockerfile.maven .').inside {
             maven cmd: 'clean deploy'
           }
           archiveArtifacts 'target/monaco-yaml-ivy-*.jar'
@@ -49,8 +62,4 @@ pipeline {
       }
     }
   }
-}
-
-def isReleaseOrMasterBranch() {
-  return env.BRANCH_NAME == 'master' || env.BRANCH_NAME.startsWith('release/') 
 }

--- a/build/sbom/pom.xml
+++ b/build/sbom/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>ch.ivyteam.monaco</groupId>
+  <artifactId>monaco-yaml-ivy-bom</artifactId>
+  <version>13.1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>nexus.ivyteam.io</id>
+      <url>https://nexus.ivyteam.io/repository/maven-snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>attach-json</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${project.basedir}/../../bom.json</file>
+                  <type>json</type>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "vite build",
     "serve": "vite preview",
     "test": "npx playwright test",
-    "test:ui": "npx playwright test --ui"
+    "test:ui": "npx playwright test --ui",
+    "sbom": "npx --yes @cyclonedx/cyclonedx-npm --output-format JSON --output-file bom.json"
   },
   "dependencies": {
     "monaco-languageserver-types": "^0.4.0",


### PR DESCRIPTION
- Generate bom
- Upload to dtrack
- Upload it as additional maven artifact to maven repository, so that we can re-integrate it (merge bom) in product core. Exactly the same approach as we re-integrate neo bom.

Will be merged to LTS 12.0

I guess this thing here is included in all designer and engine variants, right?